### PR TITLE
test: add renderer DOM tests for results and summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test:watch": "vitest",
     "lint": "npm run lint:prettier & npm run lint:ts",
     "lint:prettier": "prettier --check .",
-    "lint:ts": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "lint:ts": "tsc --noEmit"
   },
   "keywords": [
     "dat-reader",
@@ -32,10 +31,10 @@
     "protobufjs": "8.0.0"
   },
   "devDependencies": {
-    "happy-dom": "^20.8.4",
+    "happy-dom": "20.8.4",
     "prettier": "3.8.1",
     "typescript": "5.9.3",
     "vite": "8.0.0",
-    "vitest": "^4.1.0"
+    "vitest": "4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "format": "prettier --write .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "npm run lint:prettier & npm run lint:ts",
     "lint:prettier": "prettier --check .",
     "lint:ts": "tsc --noEmit",

--- a/src/renderer/results.test.ts
+++ b/src/renderer/results.test.ts
@@ -9,10 +9,7 @@ const createGeoIPEntry = (tag: string, cidrs: readonly string[]): GeoIPEntry => 
   cidrs,
 })
 
-const createGeoSiteEntry = (
-  tag: string,
-  domains: readonly DomainEntry[],
-): GeoSiteEntry => ({
+const createGeoSiteEntry = (tag: string, domains: readonly DomainEntry[]): GeoSiteEntry => ({
   tag,
   domains,
 })
@@ -42,9 +39,7 @@ describe('renderResults', () => {
   })
 
   test('renders GeoIP summary with tag and CIDR count', () => {
-    const entries: readonly GeoIPEntry[] = [
-      createGeoIPEntry('US', ['1.0.0.0/8', '2.0.0.0/16']),
-    ]
+    const entries: readonly GeoIPEntry[] = [createGeoIPEntry('US', ['1.0.0.0/8', '2.0.0.0/16'])]
     renderResults(resultsElement, entries, FILENAME)
     const summary = resultsElement.querySelector('summary')
     expect(summary).not.toBeNull()

--- a/src/renderer/results.test.ts
+++ b/src/renderer/results.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { renderResults } from './results.ts'
+import type { GeoIPEntry, GeoSiteEntry, DomainEntry } from '../types.ts'
+
+const FILENAME = 'geoip.dat' as const
+
+const createGeoIPEntry = (tag: string, cidrs: readonly string[]): GeoIPEntry => ({
+  tag,
+  cidrs,
+})
+
+const createGeoSiteEntry = (
+  tag: string,
+  domains: readonly DomainEntry[],
+): GeoSiteEntry => ({
+  tag,
+  domains,
+})
+
+describe('renderResults', () => {
+  let resultsElement: HTMLElement
+
+  beforeEach(() => {
+    resultsElement = document.createElement('div')
+  })
+
+  test('renders empty state when entries array is empty', () => {
+    renderResults(resultsElement, [], FILENAME)
+    const muted = resultsElement.querySelector('.muted')
+    expect(muted).not.toBeNull()
+    expect(muted!.textContent).toBe('No entries to display.')
+  })
+
+  test('creates details elements for GeoIP entries', () => {
+    const entries: readonly GeoIPEntry[] = [
+      createGeoIPEntry('US', ['1.0.0.0/8', '2.0.0.0/16']),
+      createGeoIPEntry('CN', ['3.0.0.0/24']),
+    ]
+    renderResults(resultsElement, entries, FILENAME)
+    const details = resultsElement.querySelectorAll('details.entry')
+    expect(details.length).toBe(2)
+  })
+
+  test('renders GeoIP summary with tag and CIDR count', () => {
+    const entries: readonly GeoIPEntry[] = [
+      createGeoIPEntry('US', ['1.0.0.0/8', '2.0.0.0/16']),
+    ]
+    renderResults(resultsElement, entries, FILENAME)
+    const summary = resultsElement.querySelector('summary')
+    expect(summary).not.toBeNull()
+    expect(summary!.textContent).toContain('[US] - 2 CIDR ranges')
+  })
+
+  test('renders copy button with lowercase tag in data attribute', () => {
+    const entries: readonly GeoIPEntry[] = [createGeoIPEntry('US', ['1.0.0.0/8'])]
+    renderResults(resultsElement, entries, FILENAME)
+    const copyButton = resultsElement.querySelector<HTMLButtonElement>('.copy-btn')
+    expect(copyButton).not.toBeNull()
+    expect(copyButton!.dataset.textToCopy).toBe('ext:geoip.dat:us')
+  })
+
+  test('renders CIDR strings in entry body', () => {
+    const cidrs = ['10.0.0.0/8', '192.168.0.0/16']
+    const entries: readonly GeoIPEntry[] = [createGeoIPEntry('PRIVATE', cidrs)]
+    renderResults(resultsElement, entries, FILENAME)
+    const entryList = resultsElement.querySelector('.entry-list')
+    expect(entryList).not.toBeNull()
+    expect(entryList!.textContent).toContain('10.0.0.0/8')
+    expect(entryList!.textContent).toContain('192.168.0.0/16')
+  })
+
+  test('renders GeoSite summary with tag and domain count', () => {
+    const entries: readonly GeoSiteEntry[] = [
+      createGeoSiteEntry('GOOGLE', [
+        { type: 2, value: 'google.com' },
+        { type: 3, value: 'www.google.com' },
+      ]),
+    ]
+    renderResults(resultsElement, entries, 'geosite.dat')
+    const summary = resultsElement.querySelector('summary')
+    expect(summary).not.toBeNull()
+    expect(summary!.textContent).toContain('[GOOGLE] - 2 domains')
+  })
+
+  test('renders domain type labels and values in entry body', () => {
+    const entries: readonly GeoSiteEntry[] = [
+      createGeoSiteEntry('EXAMPLE', [
+        { type: 0, value: 'example.com' },
+        { type: 1, value: '.*\\.example\\.com' },
+        { type: 2, value: 'example.org' },
+        { type: 3, value: 'full.example.com' },
+      ]),
+    ]
+    renderResults(resultsElement, entries, 'geosite.dat')
+    const entryList = resultsElement.querySelector('.entry-list')
+    expect(entryList).not.toBeNull()
+    expect(entryList!.textContent).toContain('[Plain] example.com')
+    expect(entryList!.textContent).toContain('[Regex] .*\\.example\\.com')
+    expect(entryList!.textContent).toContain('[Domain] example.org')
+    expect(entryList!.textContent).toContain('[Full] full.example.com')
+  })
+
+  test('clears previous content when called again', () => {
+    const firstEntries: readonly GeoIPEntry[] = [createGeoIPEntry('US', ['1.0.0.0/8'])]
+    const secondEntries: readonly GeoIPEntry[] = [
+      createGeoIPEntry('CN', ['3.0.0.0/8']),
+      createGeoIPEntry('JP', ['4.0.0.0/8']),
+    ]
+    renderResults(resultsElement, firstEntries, FILENAME)
+    renderResults(resultsElement, secondEntries, FILENAME)
+    const details = resultsElement.querySelectorAll('details.entry')
+    expect(details.length).toBe(2)
+    const summaries = resultsElement.querySelectorAll('summary')
+    expect(summaries[0]!.textContent).toContain('[CN]')
+    expect(summaries[1]!.textContent).toContain('[JP]')
+  })
+})

--- a/src/renderer/summary.test.ts
+++ b/src/renderer/summary.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { renderSummary } from './summary.ts'
+import type { SummaryData } from '../types.ts'
+
+const createSummaryData = (overrides: Partial<SummaryData> = {}): SummaryData => ({
+  filename: 'geoip.dat',
+  size: 5242880,
+  detectedType: 'geoip',
+  totals: { lists: 120, cidrs: 45000, domains: 0 },
+  ...overrides,
+})
+
+describe('renderSummary', () => {
+  let summaryPanel: HTMLElement
+  let summaryElement: HTMLElement
+
+  beforeEach(() => {
+    summaryPanel = document.createElement('div')
+    summaryPanel.hidden = true
+    summaryElement = document.createElement('div')
+  })
+
+  test('sets summaryPanel hidden to false', () => {
+    const data = createSummaryData()
+    renderSummary(summaryPanel, summaryElement, data)
+    expect(summaryPanel.hidden).toBe(false)
+  })
+
+  test('renders filename in summary', () => {
+    const data = createSummaryData({ filename: 'test-geoip.dat' })
+    renderSummary(summaryPanel, summaryElement, data)
+    expect(summaryElement.innerHTML).toContain('test-geoip.dat')
+  })
+
+  test('renders formatted file size', () => {
+    const data = createSummaryData({ size: 5242880 })
+    renderSummary(summaryPanel, summaryElement, data)
+    expect(summaryElement.innerHTML).toContain('5.0 MB')
+  })
+
+  test('renders detected type', () => {
+    const data = createSummaryData({ detectedType: 'geoip' })
+    renderSummary(summaryPanel, summaryElement, data)
+    expect(summaryElement.innerHTML).toContain('geoip')
+  })
+
+  test('renders total lists count without filter', () => {
+    const data = createSummaryData({
+      totals: { lists: 120, cidrs: 1000, domains: 0 },
+      filteredLists: undefined,
+    })
+    renderSummary(summaryPanel, summaryElement, data)
+    const listsSpan = Array.from(summaryElement.querySelectorAll('span')).find((span) =>
+      span.innerHTML.includes('Lists'),
+    )
+    expect(listsSpan).not.toBeUndefined()
+    expect(listsSpan!.textContent).toContain('120')
+    expect(listsSpan!.textContent).not.toContain('/')
+  })
+
+  test('renders filtered lists in "filtered/total" format', () => {
+    const data = createSummaryData({
+      totals: { lists: 120, cidrs: 1000, domains: 0 },
+      filteredLists: 15,
+    })
+    renderSummary(summaryPanel, summaryElement, data)
+    const listsSpan = Array.from(summaryElement.querySelectorAll('span')).find((span) =>
+      span.innerHTML.includes('Lists'),
+    )
+    expect(listsSpan).not.toBeUndefined()
+    expect(listsSpan!.textContent).toContain('15/120')
+  })
+
+  test('renders total CIDRs for GeoIP data', () => {
+    const data = createSummaryData({ totals: { lists: 10, cidrs: 5000, domains: 0 } })
+    renderSummary(summaryPanel, summaryElement, data)
+    expect(summaryElement.innerHTML).toContain('Total CIDRs')
+    expect(summaryElement.innerHTML).toContain('5000')
+  })
+
+  test('renders total domains for GeoSite data', () => {
+    const data = createSummaryData({
+      detectedType: 'geosite',
+      totals: { lists: 50, cidrs: 0, domains: 12000 },
+    })
+    renderSummary(summaryPanel, summaryElement, data)
+    expect(summaryElement.innerHTML).toContain('Total domains')
+    expect(summaryElement.innerHTML).toContain('12000')
+  })
+
+  test('renders all summary spans as children', () => {
+    const data = createSummaryData({ totals: { lists: 10, cidrs: 100, domains: 200 } })
+    renderSummary(summaryPanel, summaryElement, data)
+    const spans = summaryElement.querySelectorAll('span')
+    expect(spans.length).toBe(6)
+  })
+})

--- a/src/renderer/summary.test.ts
+++ b/src/renderer/summary.test.ts
@@ -50,7 +50,7 @@ describe('renderSummary', () => {
       filteredLists: undefined,
     })
     renderSummary(summaryPanel, summaryElement, data)
-    const listsSpan = Array.from(summaryElement.querySelectorAll('span')).find((span) =>
+    const listsSpan = Array.from(summaryElement.querySelectorAll('span')).find(span =>
       span.innerHTML.includes('Lists'),
     )
     expect(listsSpan).not.toBeUndefined()
@@ -64,7 +64,7 @@ describe('renderSummary', () => {
       filteredLists: 15,
     })
     renderSummary(summaryPanel, summaryElement, data)
-    const listsSpan = Array.from(summaryElement.querySelectorAll('span')).find((span) =>
+    const listsSpan = Array.from(summaryElement.querySelectorAll('span')).find(span =>
       span.innerHTML.includes('Lists'),
     )
     expect(listsSpan).not.toBeUndefined()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
-    "types": ["vite/client"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "include": ["src", "vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,29 +1,18 @@
-/// <reference types="vitest/config" />
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  test: {
-    environment: 'happy-dom',
-    include: ['src/**/*.test.ts'],
-  },
   base: '/dat-reader-web/',
   server: { port: 5173 },
   build: {
-    modulePreload: { polyfill: false },
-  },
-  worker: {
-    format: 'es',
-    rolldownOptions: {
+    rollupOptions: {
       output: {
-        codeSplitting: {
-          groups: [
-            {
-              name: 'protobuf',
-              test: /node_modules[\\/]protobufjs/,
-            },
-          ],
-        },
+        manualChunks: { protobuf: ['protobufjs'] },
       },
     },
+  },
+  worker: { format: 'es' },
+  test: {
+    environment: 'happy-dom',
+    include: ['src/**/*.test.ts'],
   },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,29 @@
-import { defineConfig } from 'vitest/config'
+/// <reference types="vitest/config" />
+import { defineConfig } from 'vite'
 
 export default defineConfig({
-  base: '/dat-reader-web/',
-  server: { port: 5173 },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: { protobuf: ['protobufjs'] },
-      },
-    },
-  },
-  worker: { format: 'es' },
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.test.ts'],
+  },
+  base: '/dat-reader-web/',
+  server: { port: 5173 },
+  build: {
+    modulePreload: { polyfill: false },
+  },
+  worker: {
+    format: 'es',
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: 'protobuf',
+              test: /node_modules[\\/]protobufjs/,
+            },
+          ],
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Write 9 tests for `renderResults` (empty state, GeoIP/GeoSite details, copy button format, CIDR/domain rendering, content clearing)
- Write 8 tests for `renderSummary` (panel visibility, file metadata, filtered/unfiltered lists, totals)
- Includes vitest config setup (same as other test PRs)

## Test plan
- [x] `npx vitest run` — all 17 tests pass
- [x] TypeScript checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)